### PR TITLE
chmod in mix task fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Weber - is a MVC Web framework for [Elixir](http://elixir-lang.org/).
  * Execute `mix compile` in the weber directory.
  * Create new project with: `mix weber /home/user/testWeberApplication`
 
-Now go to the `/home/user/testWeberApplication` and execute there: `mix deps.get && mix compile`. Make `sudo chomd +x ./start.sh` and after it you can try to run your testWeberApplication with:
+Now go to the `/home/user/testWeberApplication` and execute there: `mix deps.get && mix compile`. Then you can try to run your testWeberApplication with:
 
 ```
 ./start.sh

--- a/lib/mix/tasks/weber.ex
+++ b/lib/mix/tasks/weber.ex
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Weber do
         create_file path <> <<"/test/test_helper.exs">>, test
         create_file path <> <<"/test/">> <> (String.capitalize basePath) <> <<"test.exs">>, test_app(basePath)
 
-        chmod(path <> "/start.sh", "+x")
+        chmod(path <> "/start.sh", 0755)
 
     end
 


### PR DESCRIPTION
During `mix weber testWeberApp` execution:

```
** (FunctionClauseError) no function clause matching in :file.change_mode/2
    file.erl:1160: :file.change_mode("/home/mayoi/dev/tmp/weber/testWeberApp/start.sh", "+x")
    /opt/elixir/lib/mix/lib/mix/cli.ex:44: Mix.CLI.run_task/2
    /opt/elixir/lib/elixir/lib/code.ex:290: Code.require_file/2
    /opt/elixir/lib/elixir/lib/kernel/cli.ex:308: Kernel.CLI.process_command/2
    /opt/elixir/lib/elixir/lib/enum.ex:678: Enum."-map/2-lc$^0/1-0-"/2
```

According to Erlang documentation, `file:change_mode` accepts only integers as mode.
