### PR TITLE
weber.new mix task

### DIFF
--- a/lib/mix/tasks/weber.ex
+++ b/lib/mix/tasks/weber.ex
@@ -209,9 +209,10 @@ defmodule Mix.Tasks.Weber do
         def main_template(app) do
             proj = String.capitalize(app) 
             """
-            <!DOCTYPE HTML>
+            <!DOCTYPE html>
             <html>
                 <head>
+                    <meta charset="UTF-8" />
                     <title>#{proj}</title>
                 </head>
              


### PR DESCRIPTION
Also, "When in Rome, do as the Romans do". POSIX-style CLI arguments are fine, but why don't use different Mix tasks for "usage", "new" and others?
