### PR TITLE
[Proposal] Allow gzip compression

### DIFF
--- a/lib/weber/cowboy.ex
+++ b/lib/weber/cowboy.ex
@@ -21,7 +21,11 @@ defmodule Cowboy do
     {_, _host}     = :lists.keyfind(:http_host, 1, web_server_config)
     {_, port}      = :lists.keyfind(:http_port, 1, web_server_config)
     {_, acceptors} = :lists.keyfind(:acceptors, 1, web_server_config)
-    {_, ssl}     = :lists.keyfind(:ssl, 1, web_server_config)
+    {_, ssl}       = :lists.keyfind(:ssl, 1, web_server_config)
+    case :lists.keymember(:use_gzip, 1, web_server_config) do
+      true -> {_, compress} = :lists.keyfind(:use_gzip, 1, web_server_config)
+      _    -> compress = false
+    end
 
     {:ws, ws_config} = :lists.keyfind(:ws, 1, config)
     {_, ws_mod}  = :lists.keyfind(:ws_mod, 1, ws_config)
@@ -38,7 +42,8 @@ defmodule Cowboy do
                                                            {:certfile,certfile}, {:keyfile, keyfile}], 
                                                            [env: [dispatch: dispatch]])
       _ -> 
-        {:ok, _} = :cowboy.start_http(:http, acceptors, [port: port], [env: [dispatch: dispatch]])
+        {:ok, _} = :cowboy.start_http(:http, acceptors, [port: port], [env: [dispatch: dispatch],
+                                                                       compress: compress])
     end
   end
 end


### PR DESCRIPTION
Here is a proposal for allowing `gzip` compression on responses, which makes use of the `cowboy` option `compress`.

To enable, use a `config.ex` file similar to this:

``` elixir
defmodule Config do
  def config do
    [webserver:
      [http_host: "localhost",
       http_port: 8080,
       acceptors: 100,
       ssl: false,
       cacertfile_path: "",
       certfile_path: "",
       keyfile_path: "",
       use_gzip: true
      ],
    ws:
      [ws_port: 8080,
       ws_mod: :Handler
      ],
    use_internationalization: false,
    localization:
      [default_locale: :en_US,
       use_locales: [:en_US]
      ],
    use_sessions: false,
    session:
      [max_age: 1440
      ],
    log: true
    ]
  end
end
```

To disable, one can either change the `use_gzip` option above to `false` or remove it completely. 

Older projects without this change will be able to update Weber to include this change without any modifications to their code, as the change sets `compress` option for `cowboy` to false by default.

I did not include unit tests for this PR as it seems fairly trivial. If they are required/desired, please let me know, and I will see what I can do.

If this is merged, I can also send a PR to the `gh-pages` branch to update the configuration section of the [documentation](http://0xax.github.io/weber/#documentation).
