### PR TITLE
Add paragraph about request testing to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,27 @@ All websocket connections are must start with prefix `/_ws/`.
 
 [Session API](https://github.com/0xAX/weber/wiki/Weber.Session-API)
 
+## Testing requests
+
+If you're coming from a more "established" language / frameworks like ruby / ruby on rails or python / django you might be used to sophisticated test frameworks which allow you to test your requests in an very expressive way like this:
+
+```Ruby
+describe AccountsController do
+  describe "GET 'new'" do
+    it 'renders the "new" template' do
+      get 'new'
+
+      expect(response.status).to eq(200)
+      expect(response.body).to have_content('Hello my friend!')
+    end
+  end
+end
+```
+
+Unfortunately this is not possible at the moment simply because there exists no such library - however, something like this is planned for the future.
+
+The best way to test requests right now is probably how we do it: Using `exunit` and the `hackney` http client as you can see in [our own tests.] (https://github.com/0xAX/weber/blob/master/templates/default/test/response_test.exs)
+
 ## Dependencies
 
   * [cowboy](https://github.com/extend/cowboy)


### PR DESCRIPTION
Originating from here: https://github.com/0xAX/weber/issues/157 I thought it make sense to add this to the docs since this was actually the very first thing i was looking for.
