### PR TITLE
Replace deprecated term_to_binary with :erlang.term_to_binary

### DIFF
--- a/lib/weber/http/cookie.ex
+++ b/lib/weber/http/cookie.ex
@@ -1,7 +1,7 @@
 defmodule Weber.Http.Cookie do
-    
+
   def generate_session_id do
-    term_to_binary({:erlang.now, :crypto.rand_uniform(0, 1000)})
+    :erlang.term_to_binary({:erlang.now, :crypto.rand_uniform(0, 1000)})
   end
 
 end


### PR DESCRIPTION
I tried weber on the latest elixir master and got an error that `term_to_binary` was not defined. I guess it has been deprecated and removed in master in favor of the version in `:erlang`

See https://github.com/elixir-lang/elixir/commit/ce61c60af56ff55e4e7ecf821b6b3d8a1dd8a492
