### PR TITLE
Fix bug that weber can't find locale files.

### DIFF
--- a/lib/weber/i18n/localization_manager.ex
+++ b/lib/weber/i18n/localization_manager.ex
@@ -27,13 +27,13 @@ defmodule Weber.Localization.LocalizationManager do
                       |> Enum.map(fn(l) -> atom_to_binary(l) <> ".json" end)
 
         on_files_in_path(
-                         project_path <> "/deps/weber/lib/weber/i18n/localization/locale",
+                         Path.join([project_path, "/deps/weber/lib/weber/i18n/localization/locale"]),
                          &( :lists.member(&1, use_locales) ),
                          &( Weber.Localization.Locale.start_link(binary_to_atom(&1), &2) )
                         )
 
         on_files_in_path(
-                         project_path <> "/lang",
+                         Path.join([project_path, "/lang"]),
                          fn (_) -> true end,
                          &( Weber.Translation.Translate.start_link(binary_to_atom(&1), &2) )
                         )
@@ -51,7 +51,7 @@ defmodule Weber.Localization.LocalizationManager do
   end
 
   def apply_on_file(path, file, apply_fun) do
-    file_data = File.read!(path <> file)
+    file_data = File.read!(Path.join([path, file]))
     (file_data != <<>>) && apply_fun.(file, file_data)
   end
 


### PR DESCRIPTION
When I ran start.sh of exmaples/SimpleChat, I got following error.

```
** Reason for termination ==
** {{'Elixir.File.Error','__exception__',enoent,<<"read file">>,
        <<"/Users/xxx/rpm/SOURCES/weber/examples/SimpleChat/deps/weber/lib/weber/i18n/localization/localeen_US.json">>},
    [{'Elixir.File','read!',1,[{file,"lib/file.ex"},{line,205}]},
     {'Elixir.Weber.Localization.LocalizationManager',apply_on_file,3,
         [{file,"lib/weber/i18n/localization_manager.ex"},{line,54}]},
     {'Elixir.Enum','-each/2-lists^foreach/1-0-',2,
         [{file,"lib/enum.ex"},{line,517}]},
     {'Elixir.Enum',each,2,[{file,"lib/enum.ex"},{line,517}]},
     {'Elixir.Weber.Localization.LocalizationManager',handle_cast,2,
         [{file,"lib/weber/i18n/localization_manager.ex"},{line,29}]},
     {gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,604}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}
```
