### PR TITLE
Fix bug example/SimpleChat can't be launched on elixir 0.12.4

### DIFF
--- a/examples/SimpleChat/lib/helpers/Room.ex
+++ b/examples/SimpleChat/lib/helpers/Room.ex
@@ -19,16 +19,16 @@ defmodule Room do
     {:noreply, :lists.delete(pid, state)}
   end
 
-  def handle_cast({:send, pid, message, conn}, state) do  
+  def handle_cast({:send, pid, message, conn}, state) do
     case message do
       <<"get_login">> ->
         username = get_session(:username)
-        pid <- username
+        send(pid, username)
       _ ->
-        Enum.each(state, fn(user) -> 
-          send(user, message) 
+        Enum.each(state, fn(user) ->
+          send(user, message)
         end)
-    end  
+    end
     {:noreply, state}
   end
 


### PR DESCRIPTION
on elixir 0.12.4, `<-` syntax seems to be deprecated.
