### PR TITLE
Ignore files in log folder, not the logs folder

### DIFF
--- a/templates/default/.gitignore
+++ b/templates/default/.gitignore
@@ -3,4 +3,4 @@
 erl_crash.dump
 /tmp
 _build
-/logs
+/log/*


### PR DESCRIPTION
The `logs` directory is not generated as specified in `.gitignore` in the template, or when the app starts logging. It is just ``log`, and we need to ignore anything that goes inside it... Looks like logs was a typo.
