### PR TITLE
Fix issue in mix task - undefined function: HashDict.new/1

### DIFF
--- a/lib/mix/tasks/weber.ex
+++ b/lib/mix/tasks/weber.ex
@@ -57,11 +57,11 @@ defmodule Mix.Tasks.Weber do
       path = Path.expand directoryName
       baseName = Path.basename directoryName
 
-      vars = HashDict.new [
+      vars = [
         {"path", path},
         {"projectNamespace", Mix.Utils.camelize(baseName)},
         {"projectName", baseName}
-      ]
+      ] |> Enum.into HashDict.new
 
       template = "default"
       skelRoot = File.cwd! <> "/templates/" <> template


### PR DESCRIPTION
Ran into an issue running 'mix weber.new' in my environment.

Using
- Erlang/OTP 17 
- Elixir 0.13.2-dev

```
mix weber.new ~/Projects/weber_test
** (UndefinedFunctionError) undefined function: HashDict.new/1
    (elixir) HashDict.new([{"path", "~/Projects/weber_test"}, {"projectNamespace", "WeberTest"}, {"projectName", "weber_test"}])
    lib/mix/tasks/weber.ex:60: Mix.Tasks.Weber.New.run/1
    (mix) lib/mix/cli.ex:64: Mix.CLI.run_task/2
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/2
    (elixir) lib/code.ex:303: Code.require_file/2
```
