### PR TITLE
Fix 404 on static assets (Elixir 0.13.1)

### DIFF
--- a/lib/weber/utils/utils.ex
+++ b/lib/weber/utils/utils.ex
@@ -38,7 +38,7 @@ defmodule Weber.Utils do
   end
 
   def find_static_file_path(abs_filenames, filename) do
-    filter(abs_filenames, &( Path.basename(&1) == filename ) )
+    filter(abs_filenames, &( Path.basename(&1) == String.from_char_data!(filename) ) )
   end
 
   @doc """


### PR DESCRIPTION
abs_filenames is a list of path names which are char lists, but Path.basename/1 with a char list argument is apparently returning a binary in Elixir 0.13.1, this patch changes filename to a binary so the filter can find matching filenames
