### PR TITLE
Fix dependency error on latest plug package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Weber.Mixfile do
  
   defp deps(:prod) do
     [
-      {:cowboy, github: "extend/cowboy" },
+      {:cowboy, "~> 1.0.0" },
       {:jsex, github: "talentdeficit/jsex"},
       {:plug, "~> 0.5.0"},
       {:exlager, github: "khia/exlager"},


### PR DESCRIPTION
Hi,

I'm getting a dependency error with latest weber source code.

```
Unchecked dependencies for environment dev:
* cowboy (git://github.com/extend/cowboy.git)
  the dependency cowboy in deps/weber/mix.exs is overriding a child dependency:

  > In deps/weber/mix.exs:
    {:cowboy, nil, [git: "git://github.com/extend/cowboy.git"]}

  > In deps/plug/mix.exs:
    {:cowboy, nil, [hex_app: :cowboy, optional: true]}

  Ensure they match or specify one of the above in your MusicService.Mixfile deps and set `override: true`
** (Mix) Can't continue due to errors on dependencies
```

This patch fixes it.
